### PR TITLE
Gjenbrukbart oppsett for utsending av brev i altinn

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -31,7 +31,7 @@ sonarqube {
         property("sonar.organization", "navit")
         property("sonar.host.url", "https://sonarcloud.io")
         property("sonar.login", System.getenv("SONAR_TOKEN"))
-        property("sonar.exclusions", "**/Koin*,**Mock**,**/App**,**/ApacheCxfClientConfigUtils*")
+        property("sonar.exclusions", "**/Koin*,**Mock**,**/App**,**/ApacheCxfClientConfigUtils*,**/AltinnBrevRoutes*")
     }
 }
 

--- a/deploy/dev.yaml
+++ b/deploy/dev.yaml
@@ -64,3 +64,5 @@ spec:
     value: helse-spam-mottak-test
   - name: DOKARKIV_URL
     value: https://dokarkiv-q1.nais.preprod.local
+  - name: ALTINN_BREVUTSENDELSE_UI_ENABLED
+    value: true

--- a/deploy/dev.yaml
+++ b/deploy/dev.yaml
@@ -65,4 +65,4 @@ spec:
   - name: DOKARKIV_URL
     value: https://dokarkiv-q1.nais.preprod.local
   - name: ALTINN_BREVUTSENDELSE_UI_ENABLED
-    value: true
+    value: "true"

--- a/deploy/prod.yaml
+++ b/deploy/prod.yaml
@@ -68,4 +68,4 @@ spec:
     - name: DOKARKIV_URL
       value: https://dokarkiv.nais.adeo.no
     - name: ALTINN_BREVUTSENDELSE_UI_ENABLED
-      value: false
+      value: "false"

--- a/deploy/prod.yaml
+++ b/deploy/prod.yaml
@@ -67,3 +67,5 @@ spec:
       value: a01apvl00145.adeo.no:8443,a01apvl00146.adeo.no:8443,a01apvl00147.adeo.no:8443
     - name: DOKARKIV_URL
       value: https://dokarkiv.nais.adeo.no
+    - name: ALTINN_BREVUTSENDELSE_UI_ENABLED
+      value: false

--- a/docker/local/postgres/initdb.sh
+++ b/docker/local/postgres/initdb.sh
@@ -24,4 +24,16 @@ psql -v ON_ERROR_STOP=1 --username "im-varsel" --dbname "im-varsel" <<-EOSQL
     CREATE TABLE meldingsfilter (
         hash varchar(64) NOT NULL UNIQUE
     );
+
+    CREATE TABLE altinn_brev_mal (
+        data jsonb NOT NULL
+    );
+
+    CREATE TABLE altinn_brev_utsendelse (
+        id serial primary key,
+        sent bool NOT NULL DEFAULT false,
+        altinnBrevMalId varchar(64) NOT NULL,
+        behandlet timestamp,
+        virksomhetsNr varchar(9) NOT NULL
+    );
 EOSQL

--- a/src/main/kotlin/no/nav/helse/inntektsmeldingsvarsel/AltinnVarselSender.kt
+++ b/src/main/kotlin/no/nav/helse/inntektsmeldingsvarsel/AltinnVarselSender.kt
@@ -5,7 +5,7 @@ import no.altinn.services.serviceengine.correspondence._2009._10.ICorrespondence
 import no.nav.helse.arbeidsgiver.integrasjoner.dokarkiv.*
 import no.nav.helse.inntektsmeldingsvarsel.domene.varsling.PersonVarsling
 import no.nav.helse.inntektsmeldingsvarsel.domene.varsling.Varsling
-import no.nav.helse.inntektsmeldingsvarsel.joark.PDFGenerator
+import no.nav.helse.inntektsmeldingsvarsel.pdf.PDFGenerator
 import no.nav.helse.inntektsmeldingsvarsel.varsling.VarslingSender
 import no.nav.helse.inntektsmeldingsvarsel.varsling.VarslingService
 import org.slf4j.LoggerFactory

--- a/src/main/kotlin/no/nav/helse/inntektsmeldingsvarsel/Metrics.kt
+++ b/src/main/kotlin/no/nav/helse/inntektsmeldingsvarsel/Metrics.kt
@@ -22,6 +22,12 @@ val ANTALL_SENDTE_VARSLER: Counter = Counter.build()
         .help("Teller antall meldinger om manglende IM sendt til virksomheter via Altinn")
         .register()
 
+val ANTALL_SENDTE_BREV: Counter = Counter.build()
+        .namespace(METRICS_NS)
+        .name("sendte_brev")
+        .help("Teller antall brev sendt via Altinn")
+        .register()
+
 val ANTALL_PERSONER_I_SENDTE_VARSLER: Counter = Counter.build()
         .namespace(METRICS_NS)
         .name("personer_i_sendte_varsler")

--- a/src/main/kotlin/no/nav/helse/inntektsmeldingsvarsel/brevutsendelse/AltinnBrevutsendelseSender.kt
+++ b/src/main/kotlin/no/nav/helse/inntektsmeldingsvarsel/brevutsendelse/AltinnBrevutsendelseSender.kt
@@ -1,0 +1,111 @@
+package no.nav.helse.inntektsmeldingsvarsel.brevutsendelse
+
+import no.altinn.schemas.services.intermediary.receipt._2009._10.ReceiptStatusEnum
+import no.altinn.schemas.services.serviceengine.correspondence._2010._10.ExternalContentV2
+import no.altinn.schemas.services.serviceengine.correspondence._2010._10.InsertCorrespondenceV2
+import no.altinn.services.serviceengine.correspondence._2009._10.ICorrespondenceAgencyExternalBasic
+import no.nav.helse.arbeidsgiver.integrasjoner.dokarkiv.*
+import no.nav.helse.arbeidsgiver.utils.SimpleHashMapCache
+import no.nav.helse.inntektsmeldingsvarsel.pdf.PDFGenerator
+import no.nav.helse.inntektsmeldingsvarsel.brevutsendelse.repository.AltinnBrevMal
+import no.nav.helse.inntektsmeldingsvarsel.brevutsendelse.repository.AltinnBrevMalRepository
+import no.nav.helse.inntektsmeldingsvarsel.brevutsendelse.repository.AltinnBrevUtesendelse
+import org.slf4j.LoggerFactory
+import java.time.Duration
+import java.time.LocalDate
+import java.util.*
+
+class AltinnBrevutsendelseSender(
+        private val joarkClient: DokarkivKlientImpl,
+        private val malRepo: AltinnBrevMalRepository,
+        private val iCorrespondenceAgencyExternalBasic: ICorrespondenceAgencyExternalBasic,
+        private val username: String,
+        private val password: String) {
+
+    private val log = LoggerFactory.getLogger("AltinnBrevutsendelseSender")
+    private val brevMalCache = SimpleHashMapCache<AltinnBrevMal>(
+            cacheDuration = Duration.ofHours(1),
+            maxCachedItems = 2
+    )
+    private val pdfGenerator = PDFGenerator()
+
+    companion object {
+        const val SYSTEM_USER_CODE = "NAV_HELSEARBEIDSGIVER"
+    }
+
+    fun send(utsendelse: AltinnBrevUtesendelse) {
+        val mal = if (brevMalCache.hasValidCacheEntry(utsendelse.altinnBrevMalId.toString()))
+                        brevMalCache.get(utsendelse.altinnBrevMalId.toString())
+                else malRepo.get(utsendelse.altinnBrevMalId)
+
+
+        try {
+            val receiptExternal = iCorrespondenceAgencyExternalBasic.insertCorrespondenceBasicV2(
+                    username, password,
+                    SYSTEM_USER_CODE, utsendelse.id.toString(),
+                    mapToAltinnMessageFormat(utsendelse, mal)
+            )
+
+            if (receiptExternal.receiptStatusCode != ReceiptStatusEnum.OK) {
+                log.error("Fikk uventet statuskode fra Altinn {}", receiptExternal.receiptStatusCode)
+                throw IllegalStateException("Feil ved sending av brev til Altinn")
+            }
+
+            journalfør(utsendelse, mal)
+
+        } catch (e: Exception) {
+            log.error("Feil ved sending av brev til Altinn", e)
+            throw e
+        }
+    }
+
+
+    fun journalfør(brevutsendelse: AltinnBrevUtesendelse, brevmal: AltinnBrevMal): String {
+        val base64EnkodetPdf = Base64.getEncoder().encodeToString(pdfGenerator.lagPDF(brevmal))
+
+        val request = JournalpostRequest(
+                tema = brevmal.joarkTema,
+                journalposttype = Journalposttype.UTGAAENDE,
+                kanal = "ALTINN",
+                tittel = brevmal.joarkTittel,
+                bruker = Bruker(brevutsendelse.virksomhetsNr, IdType.ORGNR),
+                eksternReferanseId = "helsearbeisgiver-altinn-ut-${brevutsendelse.id}",
+                avsenderMottaker = AvsenderMottaker(
+                        brevutsendelse.virksomhetsNr,
+                        IdType.ORGNR,
+                        "Arbeidsgiver"
+                ),
+                dokumenter = listOf(Dokument(
+                        tittel = brevmal.joarkTittel,
+                        brevkode = brevmal.joarkBrevkode,
+                        dokumentVarianter = listOf(DokumentVariant(
+                                fysiskDokument = base64EnkodetPdf
+                        ))
+                )),
+                datoMottatt = LocalDate.now()
+        )
+
+        val joarkRef = joarkClient.journalførDokument(request, true, UUID.randomUUID().toString())
+
+        log.info("Journalført ${brevutsendelse.id} med respons $joarkRef")
+        return joarkRef.journalpostId
+    }
+
+    fun mapToAltinnMessageFormat(utsendelse: AltinnBrevUtesendelse, mal: AltinnBrevMal): InsertCorrespondenceV2 {
+        val meldingsInnhold = ExternalContentV2()
+                .withLanguageCode("1044")
+                .withMessageTitle(mal.header)
+                .withMessageBody(mal.bodyHtml)
+                .withMessageSummary(mal.summary)
+
+        return InsertCorrespondenceV2()
+                .withAllowForwarding(false)
+                .withReportee(utsendelse.virksomhetsNr)
+                .withMessageSender("NAV (Arbeids- og velferdsetaten)")
+                .withServiceCode(mal.altinnTjenestekode)
+                .withServiceEdition(mal.altinnTjenesteVersjon)
+                .withContent(meldingsInnhold)
+    }
+
+
+}

--- a/src/main/kotlin/no/nav/helse/inntektsmeldingsvarsel/brevutsendelse/AltinnBrevutsendelseSenderImpl.kt
+++ b/src/main/kotlin/no/nav/helse/inntektsmeldingsvarsel/brevutsendelse/AltinnBrevutsendelseSenderImpl.kt
@@ -21,7 +21,7 @@ interface AltinnBrevutsendelseSender {
 }
 
 class AltinnBrevutsendelseSenderImpl(
-        private val joarkClient: DokarkivKlientImpl,
+        private val joarkClient: DokarkivKlient,
         private val malRepo: AltinnBrevMalRepository,
         private val iCorrespondenceAgencyExternalBasic: ICorrespondenceAgencyExternalBasic,
         private val username: String,

--- a/src/main/kotlin/no/nav/helse/inntektsmeldingsvarsel/brevutsendelse/AltinnBrevutsendelseSenderImpl.kt
+++ b/src/main/kotlin/no/nav/helse/inntektsmeldingsvarsel/brevutsendelse/AltinnBrevutsendelseSenderImpl.kt
@@ -8,7 +8,7 @@ import no.nav.helse.arbeidsgiver.integrasjoner.dokarkiv.*
 import no.nav.helse.arbeidsgiver.utils.SimpleHashMapCache
 import no.nav.helse.inntektsmeldingsvarsel.ANTALL_SENDTE_BREV
 import no.nav.helse.inntektsmeldingsvarsel.pdf.PDFGenerator
-import no.nav.helse.inntektsmeldingsvarsel.brevutsendelse.repository.AltinnBrevMal
+import no.nav.helse.inntektsmeldingsvarsel.brevutsendelse.repository.AltinnBrevmal
 import no.nav.helse.inntektsmeldingsvarsel.brevutsendelse.repository.AltinnBrevMalRepository
 import no.nav.helse.inntektsmeldingsvarsel.brevutsendelse.repository.AltinnBrevUtesendelse
 import org.slf4j.LoggerFactory
@@ -28,7 +28,7 @@ class AltinnBrevutsendelseSenderImpl(
         private val password: String) : AltinnBrevutsendelseSender {
 
     private val log = LoggerFactory.getLogger("AltinnBrevutsendelseSender")
-    private val brevMalCache = SimpleHashMapCache<AltinnBrevMal>(
+    private val brevMalCache = SimpleHashMapCache<AltinnBrevmal>(
             cacheDuration = Duration.ofHours(1),
             maxCachedItems = 2
     )
@@ -65,7 +65,7 @@ class AltinnBrevutsendelseSenderImpl(
     }
 
 
-    fun journalfør(brevutsendelse: AltinnBrevUtesendelse, brevmal: AltinnBrevMal): String {
+    fun journalfør(brevutsendelse: AltinnBrevUtesendelse, brevmal: AltinnBrevmal): String {
         val base64EnkodetPdf = Base64.getEncoder().encodeToString(pdfGenerator.lagPDF(brevmal))
 
         val request = JournalpostRequest(
@@ -96,7 +96,7 @@ class AltinnBrevutsendelseSenderImpl(
         return joarkRef.journalpostId
     }
 
-    fun mapToAltinnMessageFormat(utsendelse: AltinnBrevUtesendelse, mal: AltinnBrevMal): InsertCorrespondenceV2 {
+    fun mapToAltinnMessageFormat(utsendelse: AltinnBrevUtesendelse, mal: AltinnBrevmal): InsertCorrespondenceV2 {
         val meldingsInnhold = ExternalContentV2()
                 .withLanguageCode("1044")
                 .withMessageTitle(mal.header)

--- a/src/main/kotlin/no/nav/helse/inntektsmeldingsvarsel/brevutsendelse/MockAltinnBrevutsendelseSender.kt
+++ b/src/main/kotlin/no/nav/helse/inntektsmeldingsvarsel/brevutsendelse/MockAltinnBrevutsendelseSender.kt
@@ -1,0 +1,9 @@
+package no.nav.helse.inntektsmeldingsvarsel.brevutsendelse
+
+import no.nav.helse.inntektsmeldingsvarsel.brevutsendelse.repository.AltinnBrevUtesendelse
+
+class MockAltinnBrevutsendelseSender : AltinnBrevutsendelseSender {
+    override fun send(utsendelse: AltinnBrevUtesendelse) {
+        System.out.println("Sendte ${utsendelse.id} til ${utsendelse.virksomhetsNr}")
+    }
+}

--- a/src/main/kotlin/no/nav/helse/inntektsmeldingsvarsel/brevutsendelse/SendAltinnBrevUtsendelseJob.kt
+++ b/src/main/kotlin/no/nav/helse/inntektsmeldingsvarsel/brevutsendelse/SendAltinnBrevUtsendelseJob.kt
@@ -1,0 +1,32 @@
+package no.nav.helse.inntektsmeldingsvarsel.brevutsendelse
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import no.nav.helse.inntektsmeldingsvarsel.RecurringJob
+import no.nav.helse.inntektsmeldingsvarsel.brevutsendelse.repository.AltinnBrevUtsendelseRepository
+import java.time.Duration
+import java.time.LocalDateTime
+
+class SendAltinnBrevUtsendelseJob(
+        private val repo: AltinnBrevUtsendelseRepository,
+        private val sender: AltinnBrevutsendelseSender,
+        coroutineScope: CoroutineScope = CoroutineScope(Dispatchers.IO),
+        waitTimeWhenEmptyQueue: Duration = Duration.ofMinutes(5)
+) : RecurringJob(coroutineScope, waitTimeWhenEmptyQueue) {
+
+    override fun doJob() {
+
+        var isEmpty: Boolean
+        do {
+            val varslinger = repo.getNextBatch()
+            isEmpty = varslinger.isEmpty()
+            logger.info("Sender ${varslinger.size} brev")
+
+            varslinger.forEach {
+                sender.send(it)
+                repo.updateSentStatus(it.id, LocalDateTime.now(), true)
+            }
+        } while (!isEmpty)
+    }
+
+}

--- a/src/main/kotlin/no/nav/helse/inntektsmeldingsvarsel/brevutsendelse/SendAltinnBrevUtsendelseJob.kt
+++ b/src/main/kotlin/no/nav/helse/inntektsmeldingsvarsel/brevutsendelse/SendAltinnBrevUtsendelseJob.kt
@@ -9,7 +9,7 @@ import java.time.LocalDateTime
 
 class SendAltinnBrevUtsendelseJob(
         private val repo: AltinnBrevUtsendelseRepository,
-        private val sender: AltinnBrevutsendelseSenderImpl,
+        private val sender: AltinnBrevutsendelseSender,
         coroutineScope: CoroutineScope = CoroutineScope(Dispatchers.IO),
         waitTimeWhenEmptyQueue: Duration = Duration.ofMinutes(5)
 ) : RecurringJob(coroutineScope, waitTimeWhenEmptyQueue) {

--- a/src/main/kotlin/no/nav/helse/inntektsmeldingsvarsel/brevutsendelse/SendAltinnBrevUtsendelseJob.kt
+++ b/src/main/kotlin/no/nav/helse/inntektsmeldingsvarsel/brevutsendelse/SendAltinnBrevUtsendelseJob.kt
@@ -9,7 +9,7 @@ import java.time.LocalDateTime
 
 class SendAltinnBrevUtsendelseJob(
         private val repo: AltinnBrevUtsendelseRepository,
-        private val sender: AltinnBrevutsendelseSender,
+        private val sender: AltinnBrevutsendelseSenderImpl,
         coroutineScope: CoroutineScope = CoroutineScope(Dispatchers.IO),
         waitTimeWhenEmptyQueue: Duration = Duration.ofMinutes(5)
 ) : RecurringJob(coroutineScope, waitTimeWhenEmptyQueue) {

--- a/src/main/kotlin/no/nav/helse/inntektsmeldingsvarsel/brevutsendelse/SendAltinnBrevUtsendelseJob.kt
+++ b/src/main/kotlin/no/nav/helse/inntektsmeldingsvarsel/brevutsendelse/SendAltinnBrevUtsendelseJob.kt
@@ -20,7 +20,9 @@ class SendAltinnBrevUtsendelseJob(
         do {
             val varslinger = repo.getNextBatch()
             isEmpty = varslinger.isEmpty()
-            logger.info("Sender ${varslinger.size} brev")
+            if (!isEmpty) {
+                logger.info("Sender ${varslinger.size} brev")
+            }
 
             varslinger.forEach {
                 sender.send(it)

--- a/src/main/kotlin/no/nav/helse/inntektsmeldingsvarsel/brevutsendelse/repository/AltinnBrevEntities.kt
+++ b/src/main/kotlin/no/nav/helse/inntektsmeldingsvarsel/brevutsendelse/repository/AltinnBrevEntities.kt
@@ -12,7 +12,7 @@ data class AltinnBrevUtesendelse(
         val joarkRef: String? = null
 )
 
-data class AltinnBrevMal(
+data class AltinnBrevmal(
         val id: UUID = UUID.randomUUID(),
         val header: String,
         val summary: String,

--- a/src/main/kotlin/no/nav/helse/inntektsmeldingsvarsel/brevutsendelse/repository/AltinnBrevEntities.kt
+++ b/src/main/kotlin/no/nav/helse/inntektsmeldingsvarsel/brevutsendelse/repository/AltinnBrevEntities.kt
@@ -1,0 +1,26 @@
+package no.nav.helse.inntektsmeldingsvarsel.brevutsendelse.repository
+
+import java.time.LocalDateTime
+import java.util.*
+
+data class AltinnBrevUtesendelse(
+        val id: Int,
+        val altinnBrevMalId: UUID,
+        val sent: Boolean,
+        val virksomhetsNr: String,
+        val behandlet: LocalDateTime? = null,
+        val joarkRef: String? = null
+)
+
+data class AltinnBrevMal(
+        val id: UUID = UUID.randomUUID(),
+        val header: String,
+        val summary: String,
+        val bodyHtml: String,
+        val altinnTjenestekode: String,
+        val altinnTjenesteVersjon: String,
+
+        val joarkTema: String,
+        val joarkTittel: String,
+        val joarkBrevkode: String
+)

--- a/src/main/kotlin/no/nav/helse/inntektsmeldingsvarsel/brevutsendelse/repository/AltinnBrevMalRepository.kt
+++ b/src/main/kotlin/no/nav/helse/inntektsmeldingsvarsel/brevutsendelse/repository/AltinnBrevMalRepository.kt
@@ -1,0 +1,10 @@
+package no.nav.helse.inntektsmeldingsvarsel.brevutsendelse.repository
+
+import java.util.*
+
+interface AltinnBrevMalRepository {
+    fun getAll(): Set<AltinnBrevMal>
+    fun get(id: UUID): AltinnBrevMal
+    fun insert(mal: AltinnBrevMal)
+    fun update(mal: AltinnBrevMal)
+}

--- a/src/main/kotlin/no/nav/helse/inntektsmeldingsvarsel/brevutsendelse/repository/AltinnBrevMalRepository.kt
+++ b/src/main/kotlin/no/nav/helse/inntektsmeldingsvarsel/brevutsendelse/repository/AltinnBrevMalRepository.kt
@@ -3,8 +3,8 @@ package no.nav.helse.inntektsmeldingsvarsel.brevutsendelse.repository
 import java.util.*
 
 interface AltinnBrevMalRepository {
-    fun getAll(): Set<AltinnBrevMal>
-    fun get(id: UUID): AltinnBrevMal
-    fun insert(mal: AltinnBrevMal)
-    fun update(mal: AltinnBrevMal)
+    fun getAll(): Set<AltinnBrevmal>
+    fun get(id: UUID): AltinnBrevmal
+    fun insert(mal: AltinnBrevmal)
+    fun update(mal: AltinnBrevmal)
 }

--- a/src/main/kotlin/no/nav/helse/inntektsmeldingsvarsel/brevutsendelse/repository/AltinnBrevUtsendelseRepository.kt
+++ b/src/main/kotlin/no/nav/helse/inntektsmeldingsvarsel/brevutsendelse/repository/AltinnBrevUtsendelseRepository.kt
@@ -1,0 +1,10 @@
+package no.nav.helse.inntektsmeldingsvarsel.brevutsendelse.repository
+
+import java.time.LocalDateTime
+import java.util.*
+
+interface AltinnBrevUtsendelseRepository {
+    fun insertUtsendelse(altinnMalId: UUID, virksomhetsnummere: Set<String>)
+    fun getNextBatch(): List<AltinnBrevUtesendelse>
+    fun updateSentStatus(id: Int, timeOfUpdate: LocalDateTime, status: Boolean)
+}

--- a/src/main/kotlin/no/nav/helse/inntektsmeldingsvarsel/brevutsendelse/repository/PostgresAltinnBrevUtsendelseRepository.kt
+++ b/src/main/kotlin/no/nav/helse/inntektsmeldingsvarsel/brevutsendelse/repository/PostgresAltinnBrevUtsendelseRepository.kt
@@ -14,7 +14,7 @@ class PostgresAltinnBrevUtsendelseRepository(private val ds: DataSource) : Altin
 
     private val insertStatement = "INSERT INTO $tableName(virksomhetsNr, altinnBrevMalId) VALUES "
 
-    private val updatesentStatement = "UPDATE $tableName SET sent = ?, behandlet = ? WHERE id = ?:uuid"
+    private val updatesentStatement = "UPDATE $tableName SET sent = ?, behandlet = ? WHERE id = ?"
 
     private val getBySentState = "SELECT * FROM $tableName WHERE sent=? LIMIT ?"
 

--- a/src/main/kotlin/no/nav/helse/inntektsmeldingsvarsel/brevutsendelse/repository/PostgresAltinnBrevUtsendelseRepository.kt
+++ b/src/main/kotlin/no/nav/helse/inntektsmeldingsvarsel/brevutsendelse/repository/PostgresAltinnBrevUtsendelseRepository.kt
@@ -1,0 +1,66 @@
+package no.nav.helse.inntektsmeldingsvarsel.brevutsendelse.repository
+
+import org.slf4j.LoggerFactory
+import java.sql.ResultSet
+import java.sql.Timestamp
+import java.time.LocalDateTime
+import java.util.*
+import javax.sql.DataSource
+
+class PostgresAltinnBrevUtsendelseRepository(private val ds: DataSource) : AltinnBrevUtsendelseRepository {
+
+    private val tableName = "altinn_brev_utsendelse"
+    private val logger = LoggerFactory.getLogger(PostgresAltinnBrevUtsendelseRepository::class.java)
+
+    private val insertStatement = "INSERT INTO $tableName(virksomhetsNr, altinnBrevMalId) VALUES "
+
+    private val updatesentStatement = "UPDATE $tableName SET sent = ?, behandlet = ? WHERE id = ?:uuid"
+
+    private val getBySentState = "SELECT * FROM $tableName WHERE sent=? LIMIT ?"
+
+    override fun insertUtsendelse(altinnMalId: UUID, virksomhetsnummere: Set<String>) {
+        val malId = altinnMalId.toString()
+        val validatedNumbers = virksomhetsnummere
+                .filter { orgnr -> orgnr.length == 9 && orgnr.all { it.isDigit() } }
+                .joinToString { "('$it', '$malId')" }
+
+        ds.connection.use {
+            it.prepareStatement(insertStatement + validatedNumbers).executeUpdate()
+        }
+    }
+
+    override fun getNextBatch(): List<AltinnBrevUtesendelse> {
+        ds.connection.use {
+            val resultList = ArrayList<AltinnBrevUtesendelse>()
+            val res = it.prepareStatement(getBySentState).apply {
+                setBoolean(1, false)
+                setInt(2, 500)
+            }.executeQuery()
+            while (res.next()) {
+                resultList.add(mapToDto(res))
+            }
+            return resultList
+        }
+    }
+
+    override fun updateSentStatus(id: Int, timeOfUpdate: LocalDateTime, sent: Boolean) {
+        ds.connection.use {
+            it.prepareStatement(updatesentStatement).apply {
+                setBoolean(1, sent)
+                setTimestamp(2, Timestamp.valueOf(timeOfUpdate))
+                setInt(3, id)
+            }.executeUpdate()
+        }
+    }
+
+
+    private fun mapToDto(res: ResultSet): AltinnBrevUtesendelse {
+        return AltinnBrevUtesendelse(
+                id = res.getInt("id"),
+                altinnBrevMalId = UUID.fromString(res.getString("altinnBrevMalId")),
+                sent = res.getBoolean("sent"),
+                behandlet = res.getTimestamp("behandlet")?.toLocalDateTime(),
+                virksomhetsNr = res.getString("virksomhetsNr")
+        )
+    }
+}

--- a/src/main/kotlin/no/nav/helse/inntektsmeldingsvarsel/brevutsendelse/repository/PostgresAltinnBrevmalRepository.kt
+++ b/src/main/kotlin/no/nav/helse/inntektsmeldingsvarsel/brevutsendelse/repository/PostgresAltinnBrevmalRepository.kt
@@ -1,0 +1,64 @@
+package no.nav.helse.inntektsmeldingsvarsel.brevutsendelse.repository
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
+import org.slf4j.LoggerFactory
+import java.util.*
+import javax.sql.DataSource
+import kotlin.collections.HashSet
+
+class PostgresAltinnBrevmalRepository(private val ds: DataSource, private val om: ObjectMapper) : AltinnBrevMalRepository {
+
+    private val tableName = "altinn_brev_mal"
+    private val logger = LoggerFactory.getLogger(PostgresAltinnBrevmalRepository::class.java)
+
+    private val insertStatement = "INSERT INTO $tableName (data) VALUES (?::json);"
+
+    private val updateStatement = "UPDATE $tableName SET data = ?::json where data ->> 'id' = ?"
+
+    private val getById = "SELECT data FROM $tableName WHERE data ->> 'id' = ?"
+
+    private val getAll = "SELECT data FROM $tableName"
+
+    override fun getAll(): Set<AltinnBrevMal> {
+        ds.connection.use {
+            val resultList = HashSet<AltinnBrevMal>()
+            val res = it.prepareStatement(getAll).executeQuery()
+            while (res.next()) {
+                resultList.add(om.readValue(res.getString("data")))
+            }
+            return resultList
+        }
+    }
+
+    override fun get(id: UUID): AltinnBrevMal {
+        ds.connection.use {
+            val res = it.prepareStatement(getById).apply {
+                setString(1, id.toString())
+            }.executeQuery()
+
+            if (!res.next()) {
+                throw IllegalArgumentException("$id does not exist")
+            }
+
+            return om.readValue(res.getString("data"))
+        }
+    }
+
+    override fun insert(mal: AltinnBrevMal) {
+        ds.connection.use {
+            it.prepareStatement(insertStatement).apply {
+                setString(1, om.writeValueAsString(mal))
+            }.executeUpdate()
+        }
+    }
+
+    override fun update(mal: AltinnBrevMal) {
+        ds.connection.use {
+            it.prepareStatement(updateStatement).apply {
+                setString(1, om.writeValueAsString(mal))
+                setString(2, mal.id.toString())
+            }.executeUpdate()
+        }
+    }
+}

--- a/src/main/kotlin/no/nav/helse/inntektsmeldingsvarsel/brevutsendelse/repository/PostgresAltinnBrevmalRepository.kt
+++ b/src/main/kotlin/no/nav/helse/inntektsmeldingsvarsel/brevutsendelse/repository/PostgresAltinnBrevmalRepository.kt
@@ -12,6 +12,8 @@ class PostgresAltinnBrevmalRepository(private val ds: DataSource, private val om
     private val tableName = "altinn_brev_mal"
     private val logger = LoggerFactory.getLogger(PostgresAltinnBrevmalRepository::class.java)
 
+    private val deleteStatement = "DELETE FROM $tableName where data ->> 'id' = ?"
+
     private val insertStatement = "INSERT INTO $tableName (data) VALUES (?::json);"
 
     private val updateStatement = "UPDATE $tableName SET data = ?::json where data ->> 'id' = ?"
@@ -20,9 +22,9 @@ class PostgresAltinnBrevmalRepository(private val ds: DataSource, private val om
 
     private val getAll = "SELECT data FROM $tableName"
 
-    override fun getAll(): Set<AltinnBrevMal> {
+    override fun getAll(): Set<AltinnBrevmal> {
         ds.connection.use {
-            val resultList = HashSet<AltinnBrevMal>()
+            val resultList = HashSet<AltinnBrevmal>()
             val res = it.prepareStatement(getAll).executeQuery()
             while (res.next()) {
                 resultList.add(om.readValue(res.getString("data")))
@@ -31,7 +33,7 @@ class PostgresAltinnBrevmalRepository(private val ds: DataSource, private val om
         }
     }
 
-    override fun get(id: UUID): AltinnBrevMal {
+    override fun get(id: UUID): AltinnBrevmal {
         ds.connection.use {
             val res = it.prepareStatement(getById).apply {
                 setString(1, id.toString())
@@ -45,7 +47,7 @@ class PostgresAltinnBrevmalRepository(private val ds: DataSource, private val om
         }
     }
 
-    override fun insert(mal: AltinnBrevMal) {
+    override fun insert(mal: AltinnBrevmal) {
         ds.connection.use {
             it.prepareStatement(insertStatement).apply {
                 setString(1, om.writeValueAsString(mal))
@@ -53,7 +55,15 @@ class PostgresAltinnBrevmalRepository(private val ds: DataSource, private val om
         }
     }
 
-    override fun update(mal: AltinnBrevMal) {
+    fun delete(id: UUID) {
+        ds.connection.use {
+            it.prepareStatement(deleteStatement).apply {
+                setString(1, id.toString())
+            }.executeUpdate()
+        }
+    }
+
+    override fun update(mal: AltinnBrevmal) {
         ds.connection.use {
             it.prepareStatement(updateStatement).apply {
                 setString(1, om.writeValueAsString(mal))

--- a/src/main/kotlin/no/nav/helse/inntektsmeldingsvarsel/dependencyinjection/KoinProfiles.kt
+++ b/src/main/kotlin/no/nav/helse/inntektsmeldingsvarsel/dependencyinjection/KoinProfiles.kt
@@ -122,8 +122,6 @@ fun localDevConfig(config: ApplicationConfig) = module {
     single { PdlClientImpl("", get(), get(), get()) as PdlClient }
 
     single { PostgresVarslingRepository(get()) as VarslingRepository }
-    single { PostgresAltinnBrevUtsendelseRepository(get()) as AltinnBrevUtsendelseRepository }
-    single { PostgresAltinnBrevmalRepository(get(), get()) as AltinnBrevMalRepository }
     single { PostgresMeldingsfilterRepository(get()) as MeldingsfilterRepository }
     single { VarslingService(get(), get(), get(), get(), get(), AllowAll()) }
 
@@ -132,6 +130,8 @@ fun localDevConfig(config: ApplicationConfig) = module {
     single { SendVarslingJob(get(), get()) }
     single { UpdateReadStatusJob(get(), get()) }
 
+    single { PostgresAltinnBrevUtsendelseRepository(get()) as AltinnBrevUtsendelseRepository }
+    single { PostgresAltinnBrevmalRepository(get(), get()) as AltinnBrevMalRepository }
     single { MockAltinnBrevutsendelseSender() as AltinnBrevutsendelseSender }
     single { SendAltinnBrevUtsendelseJob(get(), get()) }
 }
@@ -203,6 +203,15 @@ fun preprodConfig(config: ApplicationConfig) = module {
     single { VarslingsmeldingProcessor(get(), get()) }
     single { SendVarslingJob(get(), get()) }
     single { UpdateReadStatusJob(get(), get())}
+
+    single { PostgresAltinnBrevUtsendelseRepository(get()) as AltinnBrevUtsendelseRepository }
+    single { PostgresAltinnBrevmalRepository(get(), get()) as AltinnBrevMalRepository }
+    single { AltinnBrevutsendelseSenderImpl(get(), get(), get(),
+                config.getString("altinn_melding.username"),
+                config.getString("altinn_melding.password")
+            ) as AltinnBrevutsendelseSender
+    }
+    single { SendAltinnBrevUtsendelseJob(get(), get()) }
 }
 
 @KtorExperimentalAPI
@@ -277,6 +286,18 @@ fun prodConfig(config: ApplicationConfig) = module {
     single { SendVarslingJob(get(), get()) }
 
     single { UpdateReadStatusJob(get(), get()) }
+
+
+    single { PostgresAltinnBrevUtsendelseRepository(get()) as AltinnBrevUtsendelseRepository }
+    single { PostgresAltinnBrevmalRepository(get(), get()) as AltinnBrevMalRepository }
+    single { AltinnBrevutsendelseSenderImpl(get(), get(), get(),
+            config.getString("altinn_melding.username"),
+            config.getString("altinn_melding.password")
+    ) as AltinnBrevutsendelseSender
+    }
+    single { SendAltinnBrevUtsendelseJob(get(), get()) }
+
+
 }
 
 // utils

--- a/src/main/kotlin/no/nav/helse/inntektsmeldingsvarsel/dependencyinjection/KoinProfiles.kt
+++ b/src/main/kotlin/no/nav/helse/inntektsmeldingsvarsel/dependencyinjection/KoinProfiles.kt
@@ -23,6 +23,11 @@ import no.nav.helse.arbeidsgiver.integrasjoner.pdl.PdlClient
 import no.nav.helse.arbeidsgiver.integrasjoner.pdl.PdlClientImpl
 import no.nav.helse.arbeidsgiver.kubernetes.KubernetesProbeManager
 import no.nav.helse.inntektsmeldingsvarsel.*
+import no.nav.helse.inntektsmeldingsvarsel.brevutsendelse.SendAltinnBrevUtsendelseJob
+import no.nav.helse.inntektsmeldingsvarsel.brevutsendelse.repository.AltinnBrevMalRepository
+import no.nav.helse.inntektsmeldingsvarsel.brevutsendelse.repository.AltinnBrevUtsendelseRepository
+import no.nav.helse.inntektsmeldingsvarsel.brevutsendelse.repository.PostgresAltinnBrevUtsendelseRepository
+import no.nav.helse.inntektsmeldingsvarsel.brevutsendelse.repository.PostgresAltinnBrevmalRepository
 import no.nav.helse.inntektsmeldingsvarsel.db.createHikariConfig
 import no.nav.helse.inntektsmeldingsvarsel.db.createLocalHikariConfig
 import no.nav.helse.inntektsmeldingsvarsel.db.getDataSource
@@ -108,17 +113,22 @@ fun localDevConfig(config: ApplicationConfig) = module {
 
     single { VarslingMapper(get()) }
 
-
     single { object : RestStsClient { override fun getOidcToken(): String { return "fake token"} } as RestStsClient }
+    single {MockReadReceiptProvider() as ReadReceiptProvider}
+
     single { PdlClientImpl("", get(), get(), get()) as PdlClient }
 
     single { PostgresVarslingRepository(get()) as VarslingRepository }
+    single { PostgresAltinnBrevUtsendelseRepository(get()) as AltinnBrevUtsendelseRepository }
+    single { PostgresAltinnBrevmalRepository(get(), get()) as AltinnBrevMalRepository }
     single { PostgresMeldingsfilterRepository(get()) as MeldingsfilterRepository }
     single { VarslingService(get(), get(), get(), get(), get(), AllowAll()) }
 
     single { MockVarslingSender(get()) as VarslingSender }
     single { VarslingsmeldingProcessor(get(), get()) }
     single { SendVarslingJob(get(), get()) }
+    single { UpdateReadStatusJob(get(), get()) }
+    single { SendAltinnBrevUtsendelseJob(get(), get()) }
 }
 
 @KtorExperimentalAPI

--- a/src/main/kotlin/no/nav/helse/inntektsmeldingsvarsel/dependencyinjection/KoinProfiles.kt
+++ b/src/main/kotlin/no/nav/helse/inntektsmeldingsvarsel/dependencyinjection/KoinProfiles.kt
@@ -23,6 +23,9 @@ import no.nav.helse.arbeidsgiver.integrasjoner.pdl.PdlClient
 import no.nav.helse.arbeidsgiver.integrasjoner.pdl.PdlClientImpl
 import no.nav.helse.arbeidsgiver.kubernetes.KubernetesProbeManager
 import no.nav.helse.inntektsmeldingsvarsel.*
+import no.nav.helse.inntektsmeldingsvarsel.brevutsendelse.AltinnBrevutsendelseSender
+import no.nav.helse.inntektsmeldingsvarsel.brevutsendelse.AltinnBrevutsendelseSenderImpl
+import no.nav.helse.inntektsmeldingsvarsel.brevutsendelse.MockAltinnBrevutsendelseSender
 import no.nav.helse.inntektsmeldingsvarsel.brevutsendelse.SendAltinnBrevUtsendelseJob
 import no.nav.helse.inntektsmeldingsvarsel.brevutsendelse.repository.AltinnBrevMalRepository
 import no.nav.helse.inntektsmeldingsvarsel.brevutsendelse.repository.AltinnBrevUtsendelseRepository
@@ -128,6 +131,8 @@ fun localDevConfig(config: ApplicationConfig) = module {
     single { VarslingsmeldingProcessor(get(), get()) }
     single { SendVarslingJob(get(), get()) }
     single { UpdateReadStatusJob(get(), get()) }
+
+    single { MockAltinnBrevutsendelseSender() as AltinnBrevutsendelseSender }
     single { SendAltinnBrevUtsendelseJob(get(), get()) }
 }
 

--- a/src/main/kotlin/no/nav/helse/inntektsmeldingsvarsel/pdf/PDFGenerator.kt
+++ b/src/main/kotlin/no/nav/helse/inntektsmeldingsvarsel/pdf/PDFGenerator.kt
@@ -2,7 +2,7 @@ package no.nav.helse.inntektsmeldingsvarsel.pdf
 
 import no.nav.helse.inntektsmeldingsvarsel.domene.varsling.PersonVarsling
 import no.nav.helse.inntektsmeldingsvarsel.domene.varsling.Varsling
-import no.nav.helse.inntektsmeldingsvarsel.brevutsendelse.repository.AltinnBrevMal
+import no.nav.helse.inntektsmeldingsvarsel.brevutsendelse.repository.AltinnBrevmal
 import org.apache.pdfbox.pdmodel.PDDocument
 import org.apache.pdfbox.pdmodel.PDPage
 import org.apache.pdfbox.pdmodel.PDPageContentStream
@@ -54,7 +54,7 @@ class PDFGenerator {
         return ba
     }
 
-    fun lagPDF(mal: AltinnBrevMal): ByteArray {
+    fun lagPDF(mal: AltinnBrevmal): ByteArray {
         val doc = PDDocument()
         val page = PDPage()
         val font = PDType0Font.load(doc, this::class.java.classLoader.getResource(FONT_NAME).openStream())

--- a/src/main/kotlin/no/nav/helse/inntektsmeldingsvarsel/varsling/MockVarslingSender.kt
+++ b/src/main/kotlin/no/nav/helse/inntektsmeldingsvarsel/varsling/MockVarslingSender.kt
@@ -5,8 +5,7 @@ import no.nav.helse.inntektsmeldingsvarsel.ANTALL_SENDTE_VARSLER
 import no.nav.helse.inntektsmeldingsvarsel.domene.varsling.Varsling
 
 class MockVarslingSender(private val service: VarslingService) : VarslingSender {
-    override fun
-            send(varsling: Varsling) {
+    override fun send(varsling: Varsling) {
         println("Sender varsling med id ${varsling.uuid} til {${varsling.virksomhetsNr} med ${varsling.liste.size} personer i")
         service.oppdaterSendtStatus(varsling, true)
         ANTALL_SENDTE_VARSLER.inc()

--- a/src/main/kotlin/no/nav/helse/inntektsmeldingsvarsel/web/AltinnBrevRoutes.kt
+++ b/src/main/kotlin/no/nav/helse/inntektsmeldingsvarsel/web/AltinnBrevRoutes.kt
@@ -1,0 +1,72 @@
+package no.nav.helse.inntektsmeldingsvarsel.web
+
+import io.ktor.application.*
+import io.ktor.http.content.*
+import io.ktor.request.*
+import io.ktor.response.*
+import io.ktor.routing.*
+import io.ktor.util.*
+import no.nav.helse.inntektsmeldingsvarsel.brevutsendelse.repository.AltinnBrevMal
+import no.nav.helse.inntektsmeldingsvarsel.brevutsendelse.repository.AltinnBrevMalRepository
+import no.nav.helse.inntektsmeldingsvarsel.brevutsendelse.repository.AltinnBrevUtsendelseRepository
+import no.nav.helse.inntektsmeldingsvarsel.pdf.PDFGenerator
+import org.koin.ktor.ext.get
+import java.util.*
+
+@KtorExperimentalAPI
+fun Application.altinnBrevRoutes() {
+
+    routing {
+        static("ui") {
+            resources("brevutsendelse")
+            defaultResource("index.html", "brevutsendelse")
+        }
+    }
+
+    routing {
+        val brevMalRepository = get<AltinnBrevMalRepository>()
+
+        get("/brevmal") {
+            val mal = brevMalRepository.getAll()
+            call.respond(mal)
+        }
+
+
+        get("/brevmal/{id}") {
+            val uuid = UUID.fromString(call.parameters.get("id"))
+            val mal = brevMalRepository.get(uuid)
+            call.respond(mal)
+        }
+
+        get("/brevmal/{id}.pdf") {
+            val uuid = UUID.fromString(call.parameters.get("id"))
+            val mal = brevMalRepository.get(uuid)
+            val pdf = PDFGenerator().lagPDF(mal)
+            call.respondBytes(pdf)
+        }
+
+        put("/brevmal") {
+            val mal = call.receive<AltinnBrevMal>()
+            brevMalRepository.update(mal)
+            call.respond(mal)
+        }
+
+        post("/brevmal") {
+            val mal = call.receive<AltinnBrevMal>()
+            brevMalRepository.insert(mal)
+            call.respond(mal)
+        }
+    }
+
+    routing {
+        val brevutesendelseRepo = get<AltinnBrevUtsendelseRepository>()
+
+        post("/opprett-utsendelse") {
+            val request = call.receive<BrevutsendelseInsertRequest>()
+            brevutesendelseRepo.insertUtsendelse(request.malId, request.virksomhetsnummere)
+            call.respond("OK")
+        }
+    }
+}
+
+data class BrevutsendelseInsertRequest(val malId: UUID, val virksomhetsnummere: Set<String>)

--- a/src/main/kotlin/no/nav/helse/inntektsmeldingsvarsel/web/AltinnBrevRoutes.kt
+++ b/src/main/kotlin/no/nav/helse/inntektsmeldingsvarsel/web/AltinnBrevRoutes.kt
@@ -6,13 +6,19 @@ import io.ktor.request.*
 import io.ktor.response.*
 import io.ktor.routing.*
 import io.ktor.util.*
-import no.nav.helse.inntektsmeldingsvarsel.brevutsendelse.repository.AltinnBrevMal
+import no.nav.helse.inntektsmeldingsvarsel.brevutsendelse.repository.AltinnBrevmal
 import no.nav.helse.inntektsmeldingsvarsel.brevutsendelse.repository.AltinnBrevMalRepository
 import no.nav.helse.inntektsmeldingsvarsel.brevutsendelse.repository.AltinnBrevUtsendelseRepository
 import no.nav.helse.inntektsmeldingsvarsel.pdf.PDFGenerator
 import org.koin.ktor.ext.get
 import java.util.*
 
+
+/**
+ * Enkel UI og API ment for internt bruk.
+ *
+ * GUIet og APIet må skrus på via miljøvariabelen ALTINN_BREVUTSENDELSE_UI_ENABLED=true
+ */
 @KtorExperimentalAPI
 fun Application.altinnBrevRoutes() {
 
@@ -46,13 +52,13 @@ fun Application.altinnBrevRoutes() {
         }
 
         put("/brevmal") {
-            val mal = call.receive<AltinnBrevMal>()
+            val mal = call.receive<AltinnBrevmal>()
             brevMalRepository.update(mal)
             call.respond(mal)
         }
 
         post("/brevmal") {
-            val mal = call.receive<AltinnBrevMal>()
+            val mal = call.receive<AltinnBrevmal>()
             brevMalRepository.insert(mal)
             call.respond(mal)
         }

--- a/src/main/kotlin/no/nav/helse/inntektsmeldingsvarsel/web/App.kt
+++ b/src/main/kotlin/no/nav/helse/inntektsmeldingsvarsel/web/App.kt
@@ -16,6 +16,7 @@ import no.nav.helse.arbeidsgiver.kubernetes.LivenessComponent
 import no.nav.helse.arbeidsgiver.kubernetes.ReadynessComponent
 import no.nav.helse.inntektsmeldingsvarsel.brevutsendelse.SendAltinnBrevUtsendelseJob
 import no.nav.helse.inntektsmeldingsvarsel.dependencyinjection.getAllOfType
+import no.nav.helse.inntektsmeldingsvarsel.dependencyinjection.getString
 import no.nav.helse.inntektsmeldingsvarsel.dependencyinjection.selectModuleBasedOnProfile
 import no.nav.helse.inntektsmeldingsvarsel.varsling.SendVarslingJob
 import no.nav.helse.inntektsmeldingsvarsel.varsling.UpdateReadStatusJob
@@ -29,8 +30,6 @@ val mainLogger = LoggerFactory.getLogger("main()")
 
 @KtorExperimentalAPI
 fun main() {
-
-
     Thread.currentThread().setUncaughtExceptionHandler { thread, err ->
         mainLogger.error("uncaught exception in thread ${thread.name}: ${err.message}", err)
     }
@@ -72,7 +71,7 @@ fun main() {
     }
 }
 
-private suspend fun autoDetectProbableComponents(koin: org.koin.core.Koin) {
+private fun autoDetectProbableComponents(koin: org.koin.core.Koin) {
     val kubernetesProbeManager = koin.get<KubernetesProbeManager>()
 
     koin.getAllOfType<LivenessComponent>()
@@ -101,7 +100,9 @@ fun createApplicationEnvironment() = applicationEngineEnvironment {
         }
 
         nais()
-        altinnBrevRoutes()
+
+        if (config.getString("altinn_brevutsendelse.ui_enabled").equals("true")) {
+            altinnBrevRoutes()
+        }
     }
 }
-

--- a/src/main/kotlin/no/nav/helse/inntektsmeldingsvarsel/web/NaisRoutes.kt
+++ b/src/main/kotlin/no/nav/helse/inntektsmeldingsvarsel/web/NaisRoutes.kt
@@ -1,4 +1,4 @@
-package no.nav.helse.inntektsmeldingsvarsel.nais
+package no.nav.helse.inntektsmeldingsvarsel.web
 
 import io.ktor.application.*
 import io.ktor.http.*
@@ -12,9 +12,7 @@ import io.prometheus.client.hotspot.DefaultExports
 import no.nav.helse.arbeidsgiver.kubernetes.KubernetesProbeManager
 import no.nav.helse.arbeidsgiver.kubernetes.ProbeResult
 import no.nav.helse.arbeidsgiver.kubernetes.ProbeState
-import no.nav.helse.inntektsmeldingsvarsel.dependencyinjection.getAllOfType
 import org.koin.ktor.ext.get
-import org.koin.ktor.ext.getKoin
 import org.slf4j.LoggerFactory
 import java.util.*
 

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -46,6 +46,11 @@ altinn_melding {
   kafka_topic: ${?INNTEKTSMELDING_VARSEL_TOPIC_NAME}
 }
 
+altinn_brevutsendelse {
+  ui_enabled: false
+  ui_enabled: ${?ALTINN_BREVUTSENDELSE_UI_ENABLED}
+}
+
 database {
   username = "im-varsel"
   username = ${?DATABASE_USERNAME}

--- a/src/main/resources/brevutsendelse/index.html
+++ b/src/main/resources/brevutsendelse/index.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="no">
+<head>
+    <meta charset="UTF-8">
+    <title>Altinn Brevutsendelse</title>
+</head>
+<body>
+
+<h1>
+    Send brev i Altinn
+</h1>
+
+<h4>Meny</h4>
+
+<ul>
+    <li><a href="/ui/mal.html">Opprett brevmal</a></li>
+    <li><a href="/ui/opprett-utsending.html">Opprett utsendelse</a></li>
+</ul>
+
+<h5>Eksisterende brevmaler</h5>
+
+<ul id="brevmaler">
+<ul>Laster...</ul>
+</ul>
+
+<script>
+    let brevmalList = document.getElementById("brevmaler");
+    fetch("/brevmal").then(res => {
+        res.json().then(brevmalarray => {
+            brevmalList.innerHTML = '';
+            brevmalarray.forEach( mal => {
+                var li = document.createElement("li");
+                li.innerHTML = mal.header +
+                    ' (<a href="/brevmal/' + mal.id + '.pdf">PDF</a>' +
+                    ' | <a href="/ui/mal.html?malId=' + mal.id + '">Rediger)</a>'
+                brevmalList.appendChild(li)
+            })
+        })
+    })
+</script>
+
+</body>
+</html>

--- a/src/main/resources/brevutsendelse/mal.html
+++ b/src/main/resources/brevutsendelse/mal.html
@@ -25,6 +25,8 @@
         <br>
         <label>
             Innhold (HTML)<br>
+            PDFen som arkiveres er denne teksten minus HTML-taggene.<br>
+            Bruk linjeskift for å lage ny linje i PDFen (du kan sjekke hvordan PDFen ser ut i listevisningen)
             <textarea rows="25" cols="120" name="bodyHtml">
                  <html>
                <head>
@@ -115,7 +117,7 @@
             headers: headers,
             body: JSON.stringify(
                 {
-                    id: malIdParam,
+                    id: malIdParam || undefined,
                     header: extractValueFrom("header"),
                     summary: extractValueFrom("summary"),
                     bodyHtml: extractValueFrom("bodyHtml"),

--- a/src/main/resources/brevutsendelse/mal.html
+++ b/src/main/resources/brevutsendelse/mal.html
@@ -1,0 +1,143 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Altinn Brevutsendelse</title>
+</head>
+<body>
+
+<h1>
+    Opprett brevmal
+</h1>
+
+<form id="create-form">
+    <fieldset>
+        <label>
+            Tittel
+            <input type="text" name="header">
+        </label>
+
+        <label>
+            Sammendrag (vises i listevisningen av brevet)
+            <input type="text" name="summary">
+        </label>
+
+        <br>
+        <label>
+            Innhold (HTML)<br>
+            <textarea rows="25" cols="120" name="bodyHtml">
+                 <html>
+               <head>
+                   <meta charset="UTF-8">
+               </head>
+               <body>
+                   <div class="melding">
+
+                       <h2>Feilutsendt melding om manglende inntektsmelding</h2>
+                       <p>
+                            Du har fått en beskjed i Altinn fra NAV der vi etterlyser inntektsmelding. Dersom du allerede har sendt inn inntektsmeldingen, kan du se bort fra beskjeden fordi det har skjedd en feil hos oss. Vi tester for tiden en tjeneste for å gi arbeidsgivere beskjed om at inntektsmelding mangler. Ved en feil ble det sendt beskjed til for mange arbeidsgivere.
+                        <p>
+<p></p>
+                        <p>
+                        Vi beklager ulempen dette medfører.
+                        </p>
+
+                        <p>
+                        Hilsen NAV
+                        </p>
+                   </div>
+               </body>
+            </html>
+            </textarea>
+        </label>
+    </fieldset>
+
+    <fieldset>
+        <label>
+            Altinn-tjenestekode
+            <input type="text" name="altinnTjenestekode">
+        </label>
+
+        <label>
+            Altinn-tjenesteversjon
+            <input type="text" name="altinnTjenesteVersjon" value="1">
+        </label>
+    </fieldset>
+
+    <fieldset>
+        <label>
+            Joark Tema (SYK, PER, etc) for arkivering
+            <input type="text" name="joarkTema" value="SYK">
+        </label>
+        <label>
+            Joark-tittel (tittel som vises i gosys)
+            <input type="text" name="joarkTittel">
+        </label>
+        <label>
+            Joark-brevkode (feks altinn_brev_kostjustering_2020)
+            <input type="text" name="joarkBrevkode">
+        </label>
+    </fieldset>
+
+    <button id="sendButton" type="button" onclick="send()">Opprett</button>
+
+</form>
+
+<script>
+    const urlParams = new URLSearchParams(window.location.search);
+    window.malIdParam = urlParams.get('malId');
+    console.log(malIdParam)
+    if (window.malIdParam) {
+        document.getElementById("sendButton").innerHTML = "Oppdater"
+        fetch("/brevmal/" + window.malIdParam).then(res => {
+            res.json().then( mal => {
+                console.log(mal)
+                setValueOf("header", mal.header);
+                setValueOf("summary", mal.summary);
+                setValueOf("bodyHtml", mal.bodyHtml);
+                setValueOf("altinnTjenestekode", mal.altinnTjenestekode);
+                setValueOf("altinnTjenesteVersjon", mal.altinnTjenesteVersjon);
+                setValueOf("joarkTema", mal.joarkTema);
+                setValueOf("joarkTittel", mal.joarkTittel);
+                setValueOf("joarkBrevkode", mal.joarkBrevkode);
+            })
+        })
+    } else {
+        console.log("Ingen MalID satt")
+    }
+
+    function send() {
+        function extractValueFrom(name) { return document.getElementsByName(name)[0].value }
+        var headers = new Headers()
+        headers.append("content-type", "application/json")
+        fetch('/brevmal', {
+            method: window.malIdParam ? 'put' : 'post',
+            headers: headers,
+            body: JSON.stringify(
+                {
+                    id: malIdParam,
+                    header: extractValueFrom("header"),
+                    summary: extractValueFrom("summary"),
+                    bodyHtml: extractValueFrom("bodyHtml"),
+                    altinnTjenestekode: extractValueFrom("altinnTjenestekode"),
+                    altinnTjenesteVersjon: extractValueFrom("altinnTjenesteVersjon"),
+                    joarkTema: extractValueFrom("joarkTema"),
+                    joarkTittel: extractValueFrom("joarkTittel"),
+                    joarkBrevkode: extractValueFrom("joarkBrevkode")
+                }
+            )
+        }).then(response => {
+            alert("Lagret OK");
+            window.location = "/ui"
+        }).catch(err => {
+            alert(err);
+        })
+    }
+
+    function setValueOf(name, value) {
+        document.getElementsByName(name)[0].value = value;
+    }
+</script>
+
+</body>
+</html>

--- a/src/main/resources/brevutsendelse/opprett-utsending.html
+++ b/src/main/resources/brevutsendelse/opprett-utsending.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<html lang="no">
+<head>
+    <meta charset="UTF-8">
+    <title>Altinn Brevutsendelse</title>
+</head>
+<body>
+
+<h1>
+    Opprett utsendelse
+</h1>
+
+<form id="create-form">
+    <fieldset>
+        <label>
+            Brevmal
+            <select name="malId">
+
+            </select>
+        </label>
+
+        <br>
+        <label>
+            Virksomhetrsnummere, en på hver linje<br>
+            <textarea rows="30" cols="50" name="virksomhetsnummere"></textarea>
+        </label>
+    </fieldset>
+
+    <h4>NB: Utsendelsen starter når du trykker opprett, da er det ingen vei tilbake!</h4>
+
+    <button type="button" onclick="send()">Opprett</button>
+</form>
+
+
+<script>
+    let brevmalSelect = document.getElementsByName("malId")[0];
+    fetch("/brevmal").then(res => {
+        res.json().then(brevmalarray => {
+            brevmalarray.forEach( mal => {
+                var opt = document.createElement("option");
+                opt.value= mal.id;
+                opt.innerHTML = mal.header;
+                brevmalSelect.appendChild(opt);
+            })
+        })
+    })
+
+    function send() {
+        function extractValueFrom(name) { return document.getElementsByName(name)[0].value }
+        var headers = new Headers()
+        headers.append("content-type", "application/json")
+        fetch('/opprett-utsendelse', {
+            method: 'post',
+            headers: headers,
+            body: JSON.stringify(
+                {
+                    malId: extractValueFrom("malId"),
+                    virksomhetsnummere: extractValueFrom("virksomhetsnummere").split("\n")
+                }
+            )
+        }).then(response => {
+            alert("OK")
+        }).catch(err => {
+            alert(err)
+        })
+    }
+</script>
+
+
+</body>
+</html>

--- a/src/test/kotlin/no/nav/helse/TestData.kt
+++ b/src/test/kotlin/no/nav/helse/TestData.kt
@@ -1,5 +1,6 @@
 package no.nav.helse
 
+import no.nav.helse.inntektsmeldingsvarsel.brevutsendelse.repository.AltinnBrevUtesendelse
 import no.nav.helse.inntektsmeldingsvarsel.brevutsendelse.repository.AltinnBrevmal
 import no.nav.helse.inntektsmeldingsvarsel.domene.Periode
 import no.nav.helse.inntektsmeldingsvarsel.domene.varsling.PersonVarsling
@@ -25,6 +26,14 @@ object TestData {
         "SYK",
         "Tittelen på dokumentet i joark",
         "brevkode_i_joark"
+    )
+
+
+    val AltinnBrevutsendelse_Ubehandlet = AltinnBrevUtesendelse(
+        1,
+            AltinnBrevmal.id,
+            false,
+            "123456785",
     )
 }
 

--- a/src/test/kotlin/no/nav/helse/TestData.kt
+++ b/src/test/kotlin/no/nav/helse/TestData.kt
@@ -1,0 +1,30 @@
+package no.nav.helse
+
+import no.nav.helse.inntektsmeldingsvarsel.brevutsendelse.repository.AltinnBrevmal
+import no.nav.helse.inntektsmeldingsvarsel.domene.Periode
+import no.nav.helse.inntektsmeldingsvarsel.domene.varsling.PersonVarsling
+import no.nav.helse.inntektsmeldingsvarsel.domene.varsling.Varsling
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.util.*
+
+object TestData {
+    val Varsling = Varsling(
+            aggregatperiode = "P-W52",
+            virksomhetsNr = "123456785",
+            liste = mutableSetOf(PersonVarsling("Ole", "123", Periode(LocalDate.now(), LocalDate.now()), LocalDateTime.now()))
+    )
+
+    val AltinnBrevmal = AltinnBrevmal(
+        UUID.randomUUID(),
+        "Dette er en tittel",
+        "Dette er et sammendrag",
+        "Dette er brevet",
+        "2290",
+        "1",
+        "SYK",
+        "Tittelen på dokumentet i joark",
+        "brevkode_i_joark"
+    )
+}
+

--- a/src/test/kotlin/no/nav/helse/inntektsmeldingsvarsel/brevutsendelse/AltinnBrevutsendelseSenderImplTest.kt
+++ b/src/test/kotlin/no/nav/helse/inntektsmeldingsvarsel/brevutsendelse/AltinnBrevutsendelseSenderImplTest.kt
@@ -1,0 +1,82 @@
+package no.nav.helse.inntektsmeldingsvarsel.brevutsendelse
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import no.altinn.schemas.services.intermediary.receipt._2009._10.ReceiptExternal
+import no.altinn.schemas.services.intermediary.receipt._2009._10.ReceiptStatusEnum
+import no.altinn.schemas.services.serviceengine.correspondence._2010._10.InsertCorrespondenceV2
+import no.altinn.services.serviceengine.correspondence._2009._10.ICorrespondenceAgencyExternalBasic
+import no.nav.helse.TestData
+import no.nav.helse.arbeidsgiver.integrasjoner.dokarkiv.DokarkivKlient
+import no.nav.helse.arbeidsgiver.integrasjoner.dokarkiv.DokumentResponse
+import no.nav.helse.arbeidsgiver.integrasjoner.dokarkiv.JournalpostResponse
+import no.nav.helse.inntektsmeldingsvarsel.AltinnVarselSender
+import no.nav.helse.inntektsmeldingsvarsel.brevutsendelse.AltinnBrevutsendelseSenderImpl.Companion.SYSTEM_USER_CODE
+import no.nav.helse.inntektsmeldingsvarsel.brevutsendelse.repository.AltinnBrevMalRepository
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+class AltinnBrevutsendelseSenderImplTest {
+    val joarkMock = mockk<DokarkivKlient>()
+    val brevmalRepoMock = mockk<AltinnBrevMalRepository>()
+    val soapClientMock = mockk<ICorrespondenceAgencyExternalBasic>()
+
+    private val username = "test-username"
+    private val password = "test-password"
+
+    private val response = JournalpostResponse(
+            journalpostId = "12345",
+            journalpostFerdigstilt = true,
+            journalStatus = "J",
+            dokumenter = listOf(DokumentResponse(null,null,null))
+    )
+
+    val altinnSender = AltinnBrevutsendelseSenderImpl(
+            joarkMock,
+            brevmalRepoMock,
+            soapClientMock,
+            username,
+            password
+    )
+
+    @Test
+    fun `Henter mal, sender og journalfører`() {
+        every { joarkMock.journalførDokument(any(), any(), any()) } returns response
+        every { brevmalRepoMock.get(TestData.AltinnBrevmal.id) } returns TestData.AltinnBrevmal
+        every { soapClientMock.insertCorrespondenceBasicV2(any(), any(), any(), any(), any()) } returns ReceiptExternal().withReceiptStatusCode(ReceiptStatusEnum.OK)
+
+        altinnSender.send(TestData.AltinnBrevutsendelse_Ubehandlet)
+
+        verify(exactly = 1) { joarkMock.journalførDokument(any(), any(), any()) }
+        verify(exactly = 1) { brevmalRepoMock.get(TestData.AltinnBrevmal.id) }
+        verify(exactly = 1) {
+            soapClientMock.insertCorrespondenceBasicV2(
+                    username,
+                    password,
+                    AltinnBrevutsendelseSenderImpl.SYSTEM_USER_CODE,
+                    any(),
+                    any())
+        }
+    }
+
+    @Test
+    fun `Feiler ved ikke-ok status fra Altinn`() {
+        every { joarkMock.journalførDokument(any(), any(), any()) } returns response
+        every { brevmalRepoMock.get(TestData.AltinnBrevmal.id) } returns TestData.AltinnBrevmal
+        every { soapClientMock.insertCorrespondenceBasicV2(any(), any(), any(), any(), any()) } returns ReceiptExternal().withReceiptStatusCode(ReceiptStatusEnum.UN_EXPECTED_ERROR)
+
+        assertThrows<IllegalStateException> { altinnSender.send(TestData.AltinnBrevutsendelse_Ubehandlet) }
+
+        verify(exactly = 0) { joarkMock.journalførDokument(any(), any(), any()) }
+        verify(exactly = 1) { brevmalRepoMock.get(TestData.AltinnBrevmal.id) }
+        verify(exactly = 1) {
+            soapClientMock.insertCorrespondenceBasicV2(
+                    username,
+                    password,
+                    AltinnBrevutsendelseSenderImpl.SYSTEM_USER_CODE,
+                    any(),
+                    any())
+        }
+    }
+}

--- a/src/test/kotlin/no/nav/helse/inntektsmeldingsvarsel/pdf/PDFGeneratorTest.kt
+++ b/src/test/kotlin/no/nav/helse/inntektsmeldingsvarsel/pdf/PDFGeneratorTest.kt
@@ -1,0 +1,42 @@
+package no.nav.helse.inntektsmeldingsvarsel.pdf
+
+import no.nav.helse.TestData
+import org.apache.pdfbox.pdmodel.PDDocument
+import org.apache.pdfbox.text.PDFTextStripper
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+internal class PDFGeneratorTest {
+
+    @Test
+    fun testLagPDFVarsling() {
+        val pdf = PDFGenerator().lagPDF(TestData.Varsling, TestData.Varsling.liste)
+        assertThat(pdf).isNotNull()
+
+        val allTextInDocument = extractTextFromPdf(pdf)
+
+        TestData.Varsling.liste.forEach{
+            assertThat(allTextInDocument).contains(it.navn)
+            assertThat(allTextInDocument).contains(it.personnumer)
+        }
+    }
+
+    @Test
+    fun testLagPDFBrev() {
+        val pdf = PDFGenerator().lagPDF(TestData.AltinnBrevmal)
+        assertThat(pdf).isNotNull()
+
+        val allTextInDocument = extractTextFromPdf(pdf)
+
+        assertThat(allTextInDocument).contains(TestData.AltinnBrevmal.header)
+        assertThat(allTextInDocument).contains(TestData.AltinnBrevmal.bodyHtml)
+    }
+
+    private fun extractTextFromPdf(pdf: ByteArray): String? {
+        val pdfReader = PDDocument.load(pdf)
+        val pdfStripper = PDFTextStripper()
+        val allTextInDocument = pdfStripper.getText(pdfReader)
+        pdfReader.close()
+        return allTextInDocument
+    }
+}

--- a/src/test/kotlin/no/nav/helse/slowtests/db/PostgresAltinnBrevUtsendelseRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/helse/slowtests/db/PostgresAltinnBrevUtsendelseRepositoryTest.kt
@@ -1,0 +1,55 @@
+package no.nav.helse.slowtests.db
+
+import com.zaxxer.hikari.HikariDataSource
+import no.nav.helse.inntektsmeldingsvarsel.brevutsendelse.repository.AltinnBrevUtesendelse
+import no.nav.helse.inntektsmeldingsvarsel.brevutsendelse.repository.AltinnBrevmal
+import no.nav.helse.inntektsmeldingsvarsel.brevutsendelse.repository.PostgresAltinnBrevUtsendelseRepository
+import no.nav.helse.inntektsmeldingsvarsel.brevutsendelse.repository.PostgresAltinnBrevmalRepository
+import no.nav.helse.inntektsmeldingsvarsel.db.createLocalHikariConfig
+import no.nav.helse.inntektsmeldingsvarsel.dependencyinjection.common
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.koin.core.KoinComponent
+import org.koin.core.context.loadKoinModules
+import org.koin.core.context.startKoin
+import org.koin.core.context.stopKoin
+import org.koin.core.get
+import java.time.LocalDateTime
+import java.util.*
+
+internal class PostgresAltinnBrevUtsendelseRepositoryTest : KoinComponent {
+
+    lateinit var repo: PostgresAltinnBrevUtsendelseRepository
+    lateinit var dataSource: HikariDataSource
+
+    @BeforeEach
+    internal fun setUp() {
+        startKoin {
+            loadKoinModules(common)
+        }
+        dataSource = HikariDataSource(createLocalHikariConfig())
+        repo = PostgresAltinnBrevUtsendelseRepository(dataSource)
+    }
+
+    @Test
+    internal fun `kan inserte og hente usendte og oppdatere sendestatus`() {
+        repo.insertUtsendelse(UUID.randomUUID(), setOf("123456789", "985746364", "984759123"))
+
+        val batch = repo.getNextBatch()
+
+        assertThat(batch).hasSize(3)
+
+        batch.forEach { repo.updateSentStatus(it.id, LocalDateTime.now(), true) }
+
+        val batchAfterSentStatusUpdate = repo.getNextBatch()
+
+        assertThat(batchAfterSentStatusUpdate).hasSize(0)
+    }
+
+    @AfterEach
+    internal fun tearDown() {
+        stopKoin()
+    }
+}

--- a/src/test/kotlin/no/nav/helse/slowtests/db/PostgresAltinnBrevmalRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/helse/slowtests/db/PostgresAltinnBrevmalRepositoryTest.kt
@@ -1,6 +1,7 @@
 package no.nav.helse.slowtests.db
 
 import com.zaxxer.hikari.HikariDataSource
+import no.nav.helse.TestData
 import no.nav.helse.inntektsmeldingsvarsel.brevutsendelse.repository.AltinnBrevmal
 import no.nav.helse.inntektsmeldingsvarsel.brevutsendelse.repository.PostgresAltinnBrevmalRepository
 import no.nav.helse.inntektsmeldingsvarsel.db.createLocalHikariConfig
@@ -21,17 +22,7 @@ internal class PostgresAltinnBrevmalRepositoryTest : KoinComponent {
     lateinit var repo: PostgresAltinnBrevmalRepository
     lateinit var dataSource: HikariDataSource
 
-    private val brevmal = AltinnBrevmal(
-            UUID.randomUUID(),
-            "Dette er en tittel",
-            "Dette er et sammendrag",
-            "<body>Dette er brevet</body>",
-            "2290",
-            "1",
-            "SYK",
-            "Tittelen på dokumentet i joark",
-            "brevkode_i_joark"
-    )
+    private val brevmal = TestData.AltinnBrevmal
 
     @BeforeEach
     internal fun setUp() {

--- a/src/test/kotlin/no/nav/helse/slowtests/db/PostgresAltinnBrevmalRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/helse/slowtests/db/PostgresAltinnBrevmalRepositoryTest.kt
@@ -1,0 +1,92 @@
+package no.nav.helse.slowtests.db
+
+import com.zaxxer.hikari.HikariDataSource
+import no.nav.helse.inntektsmeldingsvarsel.brevutsendelse.repository.AltinnBrevmal
+import no.nav.helse.inntektsmeldingsvarsel.brevutsendelse.repository.PostgresAltinnBrevmalRepository
+import no.nav.helse.inntektsmeldingsvarsel.db.createLocalHikariConfig
+import no.nav.helse.inntektsmeldingsvarsel.dependencyinjection.common
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.koin.core.KoinComponent
+import org.koin.core.context.loadKoinModules
+import org.koin.core.context.startKoin
+import org.koin.core.context.stopKoin
+import org.koin.core.get
+import java.util.*
+
+internal class PostgresAltinnBrevmalRepositoryTest : KoinComponent {
+
+    lateinit var repo: PostgresAltinnBrevmalRepository
+    lateinit var dataSource: HikariDataSource
+
+    private val brevmal = AltinnBrevmal(
+            UUID.randomUUID(),
+            "Dette er en tittel",
+            "Dette er et sammendrag",
+            "<body>Dette er brevet</body>",
+            "2290",
+            "1",
+            "SYK",
+            "Tittelen på dokumentet i joark",
+            "brevkode_i_joark"
+    )
+
+    @BeforeEach
+    internal fun setUp() {
+        startKoin {
+            loadKoinModules(common)
+        }
+        dataSource = HikariDataSource(createLocalHikariConfig())
+        repo = PostgresAltinnBrevmalRepository(dataSource, get())
+    }
+
+    @Test
+    internal fun `kan inserte og hente via ID`() {
+        repo.insert(brevmal)
+        val fradb = repo.get(brevmal.id)
+        assertThat(fradb).isEqualTo(brevmal)
+    }
+
+    @Test
+    internal fun `kan oppdatere brevmal`() {
+        repo.insert(brevmal)
+
+        val endretBrevmal = brevmal.copy(
+                header = "Ny header",
+                altinnTjenestekode = "ny kode",
+                altinnTjenesteVersjon = "ny tjenesteversjon",
+                bodyHtml = "ny melding",
+                joarkBrevkode = "ny brevkode",
+                joarkTema = "nytt tema",
+                joarkTittel = "ny tittel",
+                summary = "ny oppsummering"
+        )
+
+        repo.update(endretBrevmal)
+
+        val endretFraDb = repo.get(brevmal.id)
+
+        assertThat(endretFraDb).isEqualTo(endretBrevmal)
+    }
+
+    @Test
+    internal fun `kan hente alle brevmaler`() {
+        val antall = 5
+        (1..antall).forEach {
+            repo.insert(brevmal.copy(id = UUID.randomUUID()))
+        }
+
+        val alleBrevmaler = repo.getAll()
+
+        assertThat(alleBrevmaler).hasSize(antall)
+        alleBrevmaler.forEach { repo.delete(it.id) }
+    }
+
+    @AfterEach
+    internal fun tearDown() {
+        repo.delete(brevmal.id)
+        stopKoin()
+    }
+}


### PR DESCRIPTION
Legger til støtte for å sende "villkårlige" statiske brev til en virksomhets Altinn Innboks.

Innfører en Altinn Brevmal som består av teksten som skal sendes, samt metadata for jounralføringen og utsending av malen til virksomheter.