### PR TITLE
Fikser feilmelding ved sms notifikasjon

### DIFF
--- a/src/main/kotlin/no/nav/helse/inntektsmeldingsvarsel/AltinnVarselMapper.kt
+++ b/src/main/kotlin/no/nav/helse/inntektsmeldingsvarsel/AltinnVarselMapper.kt
@@ -17,7 +17,8 @@ class AltinnVarselMapper(val altinnTjenesteKode: String) {
                 "<p>Vennlig hilsen NAV</p>")
 
         val sms = opprettSMSNotification(
-                "Vi mangler inntektsmelding fra dere og kan ikke utbetale sykepenger. Sjekk Altinn for å se hvilke ansatte du må sende inntektsmelding for. \n\nVennlig hilsen NAV"
+                "Vi mangler inntektsmelding fra dere og kan ikke utbetale sykepenger.",
+                "Sjekk Altinn for å se hvilke ansatte du må sende inntektsmelding for. \n\nVennlig hilsen NAV"
         )
 
         return NotificationBEList()


### PR DESCRIPTION
Fikser følgende feilmelding ved sms notifikasjon:
```
Antall textTokens må være 2. Var 1
```

Feilen ved ble introdusert pga. [denne endringen](https://github.com/navikt/im-varsel/commit/0e797ac4ea1cb33f3d49a28911d1cc00ecabf5b4#diff-c265945417007cda5266987b4f1d0e3b2051700adeaaec26ecc281d4d72f525bL21-L22)

`opprettNotification` forventer at teksten er en liste [med to elementer](https://github.com/navikt/im-varsel/blob/16973d63f982fdf6e114c9768565f735f67dae6d/src/main/kotlin/no/nav/helse/inntektsmeldingsvarsel/NotificationAltinnGenerator.kt#L36).