### PR TITLE
Endrer tekst for epost og sms

### DIFF
--- a/src/main/kotlin/no/nav/helse/inntektsmeldingsvarsel/AltinnVarselMapper.kt
+++ b/src/main/kotlin/no/nav/helse/inntektsmeldingsvarsel/AltinnVarselMapper.kt
@@ -13,12 +13,12 @@ class AltinnVarselMapper(val altinnTjenesteKode: String) {
 
     private fun opprettManglendeInnsendingNotifications(): NotificationBEList {
         val epost = opprettEpostNotification("Inntektsmelding mangler - sykepenger",
-                "<p>Vi mangler inntektsmelding fra dere og kan ikke utbetale sykepenger. Sjekk Altinn for å se hvilke ansatte du må sende inntektsmelding for.</p>" +
+                "<p>NAV mangler inntektsmelding for en eller flere av deres ansatte i \$reporteeName\$. Vi får ikke utbetalt penger før inntektsmeldingen er sendt. Gå til meldingsboksen i Altinn for å se hvem det gjelder, og hvilken periode det handler om.</p>" +
                 "<p>Vennlig hilsen NAV</p>")
 
         val sms = opprettSMSNotification(
-                "Vi mangler inntektsmelding fra dere og kan ikke utbetale sykepenger.",
-                "Sjekk Altinn for å se hvilke ansatte du må sende inntektsmelding for. \n\nVennlig hilsen NAV"
+                "NAV mangler inntektsmelding for en eller flere av deres ansatte i: \$reporteeName\$.",
+                "Vi får ikke utbetalt penger før inntektsmeldingen er sendt. Gå til meldingsboksen i Altinn for å se hvem det gjelder, og hvilken periode det handler om. \n\nVennlig hilsen NAV"
         )
 
         return NotificationBEList()


### PR DESCRIPTION
I følge [AltInn dokumentasjon](https://altinn.github.io/docs/utviklingsguider/digital-post-til-virksomheter/grensesnitt/):
```
$reporteeName$ = Altinn legger inn navn på virksomhet som mottar post (basert på orgnr som er angitt som mottager).
```

Ser Ole-Andre har [fjernet bruk av det](https://github.com/navikt/im-varsel/commit/0e797ac4ea1cb33f3d49a28911d1cc00ecabf5b4#diff-c265945417007cda5266987b4f1d0e3b2051700adeaaec26ecc281d4d72f525bL16).

Så kan være en grunn til det.