### PR TITLE
Legger til sjekk av fom for generering av eksternrefId

### DIFF
--- a/src/main/kotlin/no/nav/helse/inntektsmeldingsvarsel/AltinnVarselSender.kt
+++ b/src/main/kotlin/no/nav/helse/inntektsmeldingsvarsel/AltinnVarselSender.kt
@@ -94,7 +94,7 @@ class AltinnVarselSender(
 
     fun journalførEnkeltVarsel(varsel: Varsling, personVarsel: PersonVarsling): String {
         val base64EnkodetPdf = Base64.getEncoder().encodeToString(pdfGenerator.lagPDF(varsel, setOf(personVarsel)))
-        val eksternrefId = varsel.uuid +  "-" + varsel.liste.indexOfFirst { it.personnumer == personVarsel.personnumer }
+        val eksternrefId = varsel.uuid +  "-" + varsel.liste.indexOfFirst { it.personnumer == personVarsel.personnumer && personVarsel.periode.fom == it.periode.fom }
 
         val response = dokarkivKlient.journalførDokument(
                 JournalpostRequest(


### PR DESCRIPTION
Varslinger kan inneholde flere elementer - også samme person listet flere ganger med forskjellig periode, f.eks.

```json
[
    {
        "navn": "Aladdin Sane",
        "personnummer": "123456789",
        "periode": {
            "fom": "2021-01-01",
            "tom": "2021-01-04"
        }
    },
    {
        "navn": "Aladdin Sane",
        "personnummer": "123456789",
        "periode": {
            "fom": "2021-02-10",
            "tom": "2021-02-20"
        }
    }
]
```

I dette tilfelle vil det forsøkes å sende to varslinger i Altinn, men nr. 2 vil feile pga. duplikatsjekken (den kun tar hensyn til personnummer)

Tidligere genererte samme `eksternrefId` ved likt `personnummer`.

Denne PR-en endrer så vi generererer samme `eksternrefId` ved likt `personnummer` _og_ lik `periode.fom`
